### PR TITLE
Add Almeria wedding landing pages

### DIFF
--- a/src/data/landingPages.ts
+++ b/src/data/landingPages.ts
@@ -598,6 +598,33 @@ const buildDifferentiatedCityFaqs = (location: LocationEntry): LandingFaq[] => {
           answer: serviceIncludesAnswer,
         },
       ];
+    case 'saxofonista-para-bodas-en-almeria':
+      return [
+        {
+          question: '¿Encaja el saxo en bodas en terrazas, hoteles o espacios abiertos de Almería?',
+          answer: fitAnswer,
+        },
+        {
+          question: '¿Te desplazas para bodas en Almería y alrededores?',
+          answer: travelAnswer,
+        },
+        {
+          question: '¿Puedo contratar saxo para cóctel, banquete y barra libre en Almería?',
+          answer: `${location.musicAngle} Por eso en Almería muchas parejas combinan un bloque más elegante para ceremonia o cóctel con una parte más animada para banquete, barra libre o Saxo + DJ.`,
+        },
+        {
+          question: priceQuestion,
+          answer: priceAnswer,
+        },
+        {
+          question: '¿Con cuánta antelación conviene reservar en Almería?',
+          answer: timingAnswer,
+        },
+        {
+          question: serviceIncludesQuestion,
+          answer: serviceIncludesAnswer,
+        },
+      ];
     case 'saxofonista-para-bodas-en-murcia':
       return [
         {

--- a/src/data/landingPagesEn.ts
+++ b/src/data/landingPagesEn.ts
@@ -42,6 +42,20 @@ const englishCityProfiles: Record<string, EnglishCityProfile> = {
     booking:
       'For Alicante weddings, it helps to know the venue, schedule, outdoor setup and whether you want saxophone for one moment or several parts of the day.',
   },
+  'saxofonista-para-bodas-en-almeria': {
+    intro:
+      'Almeria is a Mediterranean wedding location shaped by bright light, dry climate, terraces, hotels and open-air venues near the sea or across the province.',
+    logistics:
+      'The service adapts to outdoor ceremonies, hotel weddings, coastal terraces and estates where timing, sound setup and guest flow are especially important.',
+    music:
+      'Live saxophone can begin with an elegant ceremony or cocktail atmosphere and then grow into a more interactive banquet, open-bar or Sax + DJ moment.',
+    venueStyle: 'hotels, terraces, estates, coastal spaces and Mediterranean weddings in Almeria',
+    nearbyContext: 'Roquetas de Mar, El Ejido, Aguadulce and nearby areas of the province',
+    fit:
+      'In Almeria, saxophone works especially well for Mediterranean weddings that move through outdoor spaces and need a balance of elegance, atmosphere and party energy.',
+    booking:
+      'For Almeria weddings, it helps to share the date, venue, whether the performance is indoors or outdoors, and which moments you want to highlight with live saxophone.',
+  },
   'saxofonista-para-bodas-en-barcelona': {
     intro:
       'Barcelona combines urban weddings, destination celebrations, boutique hotels and masias where design, production and guest experience are usually very important.',

--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -152,8 +152,8 @@ const seeds: Seed[] = [
     'Llevo un formato pensado para bodas en Almería donde el clima, las terrazas y los espacios abiertos piden una música elegante y adaptable al ambiente.',
     'cobertura en la provincia de Almería y repertorio para bodas costeras',
     'Boda en Andalucía',
-    3,
-    ['saxofonista-para-bodas-en-granada', 'saxofonista-para-bodas-en-murcia'],
+    1,
+    ['saxofonista-para-bodas-en-malaga', 'saxofonista-para-bodas-en-murcia'],
   ],
   [
     'Ávila',
@@ -832,11 +832,11 @@ const locationOverrides: Record<string, Partial<LocationEntry>> = {
   },
   'saxofonista-para-bodas-en-almeria': {
     serviceContext:
-        'Almería es una provincia donde muchas bodas se celebran en terrazas, hoteles y espacios abiertos donde el clima, el paisaje y la amplitud del lugar condicionan mucho el ritmo del evento. En estas celebraciones suele funcionar muy bien una música elegante al principio y una fiesta más libre después.',
+      'Almería es una ciudad mediterránea con bodas muy marcadas por la luz, el clima seco, las terrazas, los hoteles y los espacios abiertos cerca del mar o en fincas de la provincia. En este tipo de celebraciones suele funcionar muy bien una propuesta musical que acompañe con elegancia al inicio y gane energía cuando llega el banquete o la barra libre.',
     logisticsAngle:
-      'En Almería suelen ser importantes los montajes en espacios abiertos, hoteles, terrazas y bodas costeras donde el horario y el sonido tienen mucho peso.',
+      'En Almería suelen ser importantes los montajes en exterior, la coordinación con hoteles, terrazas, fincas y espacios costeros, y un sonido bien planteado para que el directo encaje con el ritmo real del evento.',
     musicAngle:
-      'En Almería suele funcionar muy bien un servicio que arranca elegante en ceremonia o cóctel y termina con mucha interacción en banquete o barra libre.',
+      'En Almería suele funcionar muy bien un servicio que arranca elegante en ceremonia o cóctel y termina con más interacción en banquete, entrada a barra libre o formato Saxo + DJ.',
     bookingAngle:
       'Para bodas en Almería, lo más práctico es definir fecha, espacio, si hay exterior o interior y qué momentos queréis reforzar con el saxo.',
     venueStyle: 'hoteles, terrazas, fincas y espacios de boda de la provincia de Almería',
@@ -845,6 +845,18 @@ const locationOverrides: Record<string, Partial<LocationEntry>> = {
       'Cobertura habitual en Almería, Roquetas de Mar, El Ejido y Aguadulce.',
       'Muy buena adaptación a bodas costeras y celebraciones donde el directo debe acompañar sin frenar el ritmo del evento.',
     ],
+    faqVariants: {
+      price:
+        'En Almería el presupuesto depende de la fecha, el espacio, el desplazamiento, el montaje en interior o exterior y si queréis saxo en uno o varios momentos de la boda.',
+      fit:
+        'Sí. En Almería el saxo encaja muy bien en bodas mediterráneas, terrazas, hoteles, fincas y espacios abiertos donde se busca una mezcla de elegancia, ambiente y fiesta.',
+      travel:
+        'Sí. Trabajo bodas en Almería y zonas cercanas como Roquetas de Mar, El Ejido y Aguadulce, coordinando horarios, montaje y necesidades de sonido con cada espacio.',
+      timing:
+        'En Almería conviene consultar disponibilidad con tiempo, especialmente en primavera, verano y fechas con mucha demanda de bodas en espacios exteriores o costeros.',
+      personalization:
+        'Sí. El repertorio y la intensidad del directo se adaptan al estilo de la boda, al espacio y a si queréis más protagonismo en ceremonia, cóctel, banquete o barra libre.',
+    },
   },
   'saxofonista-para-bodas-en-barcelona': {
     serviceContext:
@@ -1066,6 +1078,7 @@ export const getLaunchedLocations = () => launchedLocations;
 
 export const getEnglishLocationName = (location: LocationEntry) => {
   const englishNames: Record<string, string> = {
+    Almería: 'Almeria',
     Málaga: 'Malaga',
     Palma: 'Mallorca',
     Sevilla: 'Seville',


### PR DESCRIPTION
## Summary
- Add Spanish Almeria wedding landing page content and localized FAQ variants
- Add English Almeria saxophonist landing page profile
- Include Almeria in English location naming so /en/saxophonist-almeria builds correctly

## Validation
- npm.cmd run build